### PR TITLE
feat: Add configurable segment styles and color support

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,42 @@
+{
+  "theme": "dark",
+  "segments": {
+    "model": {
+      "enabled": true,
+      "style": {
+        "color": 36,
+        "bold": false,
+        "dim": true
+      }
+    },
+    "directory": {
+      "enabled": true,
+      "style": {
+        "color": 33,
+        "bold": true,
+        "dim": false
+      }
+    },
+    "git": {
+      "enabled": true,
+      "style": {
+        "color": 34,
+        "bold": true,
+        "dim": false
+      }
+    },
+    "usage": {
+      "enabled": true,
+      "style": {
+        "color": 35,
+        "bold": false,
+        "dim": false
+      }
+    },
+    "separator": {
+      "color": 90,
+      "bold": false,
+      "dim": false
+    }
+  }
+}

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -1,24 +1,47 @@
-use super::types::{Config, SegmentsConfig};
-
-pub const DEFAULT_CONFIG: Config = Config {
-    theme: String::new(), // Set to "dark" at runtime
-    segments: SegmentsConfig {
-        directory: true,
-        git: true,
-        model: true,
-        usage: true,
-    },
-};
+use super::types::{Config, SegmentsConfig, SegmentConfig, SegmentStyle};
 
 impl Default for Config {
     fn default() -> Self {
         Config {
             theme: "dark".to_string(),
             segments: SegmentsConfig {
-                directory: true,
-                git: true,
-                model: true,
-                usage: true,
+                model: SegmentConfig {
+                    enabled: true,
+                    style: SegmentStyle {
+                        color: 36,
+                        bold: false,
+                        dim: true,
+                    },
+                },
+                directory: SegmentConfig {
+                    enabled: true,
+                    style: SegmentStyle {
+                        color: 33,
+                        bold: true,
+                        dim: false,
+                    },
+                },
+                git: SegmentConfig {
+                    enabled: true,
+                    style: SegmentStyle {
+                        color: 34,
+                        bold: true,
+                        dim: false,
+                    },
+                },
+                usage: SegmentConfig {
+                    enabled: true,
+                    style: SegmentStyle {
+                        color: 35,
+                        bold: false,
+                        dim: false,
+                    },
+                },
+                separator: SegmentStyle {
+                    color: 90,
+                    bold: false,
+                    dim: false,
+                },
             },
         }
     }

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -1,16 +1,45 @@
 use super::types::Config;
 use std::path::Path;
+use std::fs;
 
 pub struct ConfigLoader;
 
 impl ConfigLoader {
     pub fn load() -> Config {
-        // Return default config for now, implement multi-layer loading later
+        // Try to load from standard locations
+        let config_paths = [
+            "ccline.json",
+            "ccline.toml", 
+            "config.json",
+            "config.toml",
+        ];
+        
+        for path in &config_paths {
+            if let Ok(config) = Self::load_from_path(path) {
+                return config;
+            }
+        }
+        
+        // Return default config if no config file found
         Config::default()
     }
     
-    pub fn load_from_path<P: AsRef<Path>>(_path: P) -> Result<Config, Box<dyn std::error::Error>> {
-        // Load config from file
-        Ok(Config::default())
+    pub fn load_from_path<P: AsRef<Path>>(path: P) -> Result<Config, Box<dyn std::error::Error>> {
+        let path = path.as_ref();
+        let content = fs::read_to_string(path)?;
+        
+        let config = if let Some(ext) = path.extension() {
+            match ext.to_str() {
+                Some("json") => serde_json::from_str(&content)?,
+                Some("toml") => toml::from_str(&content)?,
+                _ => return Err("Unsupported config file format".into()),
+            }
+        } else {
+            // Try JSON first, then TOML
+            serde_json::from_str(&content)
+                .or_else(|_| toml::from_str(&content))?
+        };
+        
+        Ok(config)
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,4 +4,3 @@ pub mod defaults;
 
 pub use types::*;
 pub use loader::ConfigLoader;
-pub use defaults::DEFAULT_CONFIG;

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -8,10 +8,24 @@ pub struct Config {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SegmentsConfig {
-    pub directory: bool,
-    pub git: bool,
-    pub model: bool,
-    pub usage: bool,
+    pub directory: SegmentConfig,
+    pub git: SegmentConfig,
+    pub model: SegmentConfig,
+    pub usage: SegmentConfig,
+    pub separator: SegmentStyle,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SegmentConfig {
+    pub enabled: bool,
+    pub style: SegmentStyle,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SegmentStyle {
+    pub color: u8,
+    pub bold: bool,
+    pub dim: bool,
 }
 
 // Data structures compatible with existing main.rs

--- a/src/core/statusline.rs
+++ b/src/core/statusline.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, InputData};
+use crate::config::{Config, InputData, SegmentStyle};
 use crate::core::segments::{DirectorySegment, GitSegment, ModelSegment, UsageSegment, Segment};
 
 pub struct StatusLineGenerator {
@@ -10,39 +10,60 @@ impl StatusLineGenerator {
         Self { config }
     }
     
+    fn format_with_style(&self, content: &str, style: &SegmentStyle) -> String {
+        let mut codes = Vec::new();
+        
+        if style.bold {
+            codes.push("1".to_string());
+        } else {
+            codes.push("22".to_string()); // Explicitly disable bold
+        }
+        
+        if style.dim {
+            codes.push("2".to_string());
+        }
+        
+        codes.push(style.color.to_string());
+        
+        format!("\x1b[{}m{}\x1b[0m", codes.join(";"), content)
+    }
+    
     pub fn generate(&self, input: &InputData) -> String {
         let mut segments = Vec::new();
         
-        // Assemble segments with proper colors
-        if self.config.segments.model {
+        // Generate segments using configured styles
+        if self.config.segments.model.enabled {
             let model_segment = ModelSegment::new(true);
             let content = model_segment.render(input);
-            segments.push(format!("\x1b[1;36m{}\x1b[0m", content));
+            segments.push(self.format_with_style(&content, &self.config.segments.model.style));
         }
         
-        if self.config.segments.directory {
+        if self.config.segments.directory.enabled {
             let dir_segment = DirectorySegment::new(true);
             let content = dir_segment.render(input);
             // Extract directory name without icon
             let dir_name = content.trim_start_matches('\u{f024b}').trim_start();
-            segments.push(format!("\x1b[1;33m\u{f024b}\x1b[0m \x1b[1;32m{}\x1b[0m", dir_name));
+            let icon_formatted = self.format_with_style("\u{f024b}", &self.config.segments.directory.style);
+            let dir_formatted = self.format_with_style(dir_name, &self.config.segments.directory.style);
+            segments.push(format!("{} {}", icon_formatted, dir_formatted));
         }
         
-        if self.config.segments.git {
+        if self.config.segments.git.enabled {
             let git_segment = GitSegment::new(true);
             let git_output = git_segment.render(input);
             if !git_output.is_empty() {
-                segments.push(format!("\x1b[1;34m{}\x1b[0m", git_output));
+                segments.push(self.format_with_style(&git_output, &self.config.segments.git.style));
             }
         }
         
-        if self.config.segments.usage {
+        if self.config.segments.usage.enabled {
             let usage_segment = UsageSegment::new(true);
             let content = usage_segment.render(input);
-            segments.push(format!("\x1b[1;35m{}\x1b[0m", content));
+            segments.push(self.format_with_style(&content, &self.config.segments.usage.style));
         }
         
-        // Join segments with white separator
-        segments.join("\x1b[37m | \x1b[0m")
+        // Join segments with configured separator style
+        let separator = self.format_with_style(" | ", &self.config.segments.separator);
+        segments.join(&separator)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,17 @@ fn main() -> io::Result<()> {
     }
     
     // Load configuration
-    let config = ConfigLoader::load();
+    let config = if let Some(config_path) = &cli.config {
+        match ConfigLoader::load_from_path(config_path) {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("Error loading config from {}: {}", config_path, e);
+                std::process::exit(1);
+            }
+        }
+    } else {
+        ConfigLoader::load()
+    };
     
     // Read Claude Code data from stdin
     let stdin = io::stdin();


### PR DESCRIPTION
- Replace boolean segment configs with SegmentConfig containing style options
- Add SegmentStyle struct with color, bold, and dim properties
- Implement JSON/TOML configuration file loading with CLI argument support
- Add format_with_style() method with proper ANSI color code handling
- Fix bold/dim interaction by explicitly disabling bold when needed
- Support custom config file paths via -c/--config argument
- Include config.example.json as reference configuration

## Summary by Sourcery

Add configurable segment styling and color support, replace boolean segment flags with style-based configs, implement JSON/TOML config loading with CLI path option, and handle ANSI formatting with proper bold/dim behavior

New Features:
- Introduce per-segment style configuration (color, bold, dim) via SegmentConfig and SegmentStyle
- Implement JSON and TOML configuration file loading from standard locations
- Add CLI support for custom config file paths via -c/--config

Bug Fixes:
- Fix bold/dim interaction by explicitly disabling bold when dim is applied

Enhancements:
- Replace boolean segment toggles with SegmentConfig including a styled separator
- Add format_with_style method to apply ANSI color codes with correct bold and dim handling

Documentation:
- Include config.example.json as a reference configuration