### PR TITLE
fix: sync all package.json versions to 1.0.4 to fix pnpm global updates

### DIFF
--- a/npm/main/package.json
+++ b/npm/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cometix/ccline",
-  "version": "0.0.0",
+  "version": "1.0.4",
   "description": "CCometixLine - High-performance Claude Code StatusLine tool",
   "bin": {
     "ccline": "./bin/ccline.js"
@@ -9,11 +9,11 @@
     "postinstall": "node scripts/postinstall.js"
   },
   "optionalDependencies": {
-    "@cometix/ccline-darwin-x64": "0.0.0",
-    "@cometix/ccline-darwin-arm64": "0.0.0",
-    "@cometix/ccline-linux-x64": "0.0.0",
-    "@cometix/ccline-linux-x64-musl": "0.0.0",
-    "@cometix/ccline-win32-x64": "0.0.0"
+    "@cometix/ccline-darwin-x64": "1.0.4",
+    "@cometix/ccline-darwin-arm64": "1.0.4",
+    "@cometix/ccline-linux-x64": "1.0.4",
+    "@cometix/ccline-linux-x64-musl": "1.0.4",
+    "@cometix/ccline-win32-x64": "1.0.4"
   },
   "repository": {
     "type": "git",

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cometix/ccline-darwin-arm64",
-  "version": "0.0.0",
+  "version": "1.0.4",
   "description": "macOS ARM64 binary for CCometixLine",
   "files": ["ccline"],
   "os": ["darwin"],

--- a/npm/platforms/darwin-x64/package.json
+++ b/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cometix/ccline-darwin-x64",
-  "version": "0.0.0",
+  "version": "1.0.4",
   "description": "macOS x64 binary for CCometixLine",
   "files": ["ccline"],
   "os": ["darwin"],

--- a/npm/platforms/linux-x64-musl/package.json
+++ b/npm/platforms/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cometix/ccline-linux-x64-musl",
-  "version": "0.0.0",
+  "version": "1.0.4",
   "description": "Linux x64 static binary for CCometixLine (musl libc)",
   "files": ["ccline"],
   "os": ["linux"],

--- a/npm/platforms/linux-x64/package.json
+++ b/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cometix/ccline-linux-x64",
-  "version": "0.0.0",
+  "version": "1.0.4",
   "description": "Linux x64 binary for CCometixLine",
   "files": ["ccline"],
   "os": ["linux"],

--- a/npm/platforms/win32-x64/package.json
+++ b/npm/platforms/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cometix/ccline-win32-x64",
-  "version": "0.0.0",
+  "version": "1.0.4",
   "description": "Windows x64 binary for CCometixLine",
   "files": ["ccline.exe"],
   "os": ["win32"],


### PR DESCRIPTION
- Update main package.json version from 0.0.0 to 1.0.4
- Update all platform-specific package.json versions to 1.0.4
- Fix optionalDependencies version references in main package
- Resolves issue where `pnpm upgrade -g @cometix/ccline` couldn't detect updates

🤖 Generated with [Claude Code](https://claude.ai/code)