### PR TITLE
Add a related projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,10 @@ cargo build --release
 
 Contributions are welcome! Please feel free to submit issues or pull requests.
 
+## Related Projects
+
+- [tweakcc](https://github.com/Piebald-AI/tweakcc) - Command-line tool to customize your Claude Code themes, thinking verbs, and more.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
Hi!  CCometixLine is quite a convenient little tool!  I thought I'd add a link to our own tool, [tweakcc](https://github.com/Piebald-AI/tweakcc), which has a related, although different, purpose.  I've [linked](https://github.com/Piebald-AI/tweakcc?tab=readme-ov-file#related-projects) CCometixLine in tweakcc's README too.

I also strongly recommend that you submit CCometixLine to [Awesome Claude Code](https://github.com/hesreallyhim/awesome-claude-code).  They're looking for statusline projects exactly like this one and it will get you more visibility&mdash;they have 12.8k stars.

## Summary by Sourcery

Documentation:
- Add a Related Projects header and include a link to the tweakcc command-line customization tool in the README