### PR TITLE
fix: handle icon selector input and selection logic properly

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -165,11 +165,10 @@ impl App {
                             app.icon_selector.start_custom_input()
                         }
                         KeyCode::Enter => {
-                            if app.icon_selector.editing_custom {
-                                app.icon_selector.finish_custom_input();
-                                if app.icon_selector.custom_input.is_empty() {
-                                    continue;
-                                }
+                            if app.icon_selector.editing_custom
+                                && !app.icon_selector.finish_custom_input()
+                            {
+                                continue;
                             }
                             if let Some(icon) = app.icon_selector.get_selected_icon() {
                                 app.apply_selected_icon(icon);

--- a/src/ui/components/icon_selector.rs
+++ b/src/ui/components/icon_selector.rs
@@ -119,11 +119,13 @@ impl IconSelectorComponent {
         self.custom_input.clear();
     }
 
-    pub fn finish_custom_input(&mut self) {
+    pub fn finish_custom_input(&mut self) -> bool {
         self.editing_custom = false;
         if !self.custom_input.is_empty() {
             self.current_icon = Some(self.custom_input.clone());
+            return true;
         }
+        false
     }
 
     pub fn input_char(&mut self, c: char) {


### PR DESCRIPTION
修复了在图标选择的模式下自定义图标无法保存且无法输入字符'c'的bug

## Summary by Sourcery

Ensure icon selector custom input can be started and applied correctly, and prevent invalid submissions.

Bug Fixes:
- Prevent starting custom icon input when already editing to avoid conflicting key handling.
- Allow applying selected or custom icons only when a non-empty value is provided, avoiding empty icon saves.