### PR TITLE
feat: support Claude Code native context_window API

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -149,7 +149,7 @@ pub struct CurrentContextUsage {
 impl ContextWindow {
     pub fn total_tokens(&self) -> Option<u32> {
         match (self.total_input_tokens, self.total_output_tokens) {
-            (Some(input), Some(output)) => Some(input + output),
+            (Some(input), Some(output)) => Some(input.saturating_add(output)),
             (Some(input), None) => Some(input),
             (None, Some(output)) => Some(output),
             (None, None) => None,
@@ -163,13 +163,15 @@ impl ContextWindow {
             || self.used_percentage.is_some()
     }
 
-    pub fn get_display_percentage(&self) -> Option<f64> {
+    /// Calculate display percentage with provided context limit.
+    /// If used_percentage is available, returns it directly.
+    /// Otherwise calculates from total_tokens divided by the provided limit.
+    pub fn get_display_percentage(&self, context_limit: u32) -> Option<f64> {
         if let Some(percentage) = self.used_percentage {
             Some(percentage)
         } else if self.is_available() {
             self.total_tokens().map(|tokens| {
-                let limit = self.context_window_size.unwrap_or(200000);
-                (tokens as f64 / limit as f64) * 100.0
+                (tokens as f64 / context_limit as f64) * 100.0
             })
         } else {
             None


### PR DESCRIPTION
- Add ContextWindow struct to support native Claude Code v2.0.37+ context window data
- Prioritize native context_window field for accurate token usage
- Maintain backward compatibility with transcript parsing fallback
- Add session history search as additional fallback mechanism
- Improve percentage calculation and token display formatting

## Summary by Sourcery

Support native context window metadata from Claude Code while preserving existing transcript-based fallbacks for token usage display.

New Features:
- Introduce a ContextWindow and CurrentContextUsage schema on InputData to consume native context window data from Claude Code.

Enhancements:
- Prioritize native context window size and usage for computing context limits and usage percentages, with improved percentage and token display formatting.
- Add session history search as an additional fallback when deriving token usage from transcripts.