### PR TITLE
fix(usage): show session reset time and add configurable reset display

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,30 @@ All segments are configurable with:
 
 Supported segments: Directory, Git, Model, Usage, Time, Cost, OutputStyle
 
+### Usage Segment Options
+
+The `usage` segment displays Claude API usage from the `/api/oauth/usage` endpoint and supports the following options:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `api_base_url` | string | `"https://api.anthropic.com"` | Base URL for the Anthropic API |
+| `cache_duration` | integer | `300` | How long to cache API results (seconds) |
+| `timeout` | integer | `2` | API request timeout (seconds) |
+| `reset_period` | string | `"session"` | Which reset time to display: `"session"` (5-hour window) or `"weekly"` (7-day window) |
+| `reset_format` | string | `"time"` | How to format the reset time: `"time"` (e.g. `2-22-13`) or `"duration"` (e.g. `4h 52m`) |
+
+Example configuration:
+
+```toml
+[[segments]]
+id = "usage"
+enabled = true
+
+[segments.options]
+reset_period = "session"
+reset_format = "duration"
+cache_duration = 180
+```
 
 ## Requirements
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -255,6 +255,30 @@ CCometixLine 支持通过 TOML 文件和交互式 TUI 进行完整配置：
 
 支持的段落：目录、Git、模型、使用量、时间、成本、输出样式
 
+### 使用量段落选项
+
+`usage` 段落通过 `/api/oauth/usage` 接口显示 Claude API 使用情况，支持以下选项：
+
+| 选项 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `api_base_url` | 字符串 | `"https://api.anthropic.com"` | Anthropic API 的基础 URL |
+| `cache_duration` | 整数 | `300` | API 结果缓存时长（秒） |
+| `timeout` | 整数 | `2` | API 请求超时时间（秒） |
+| `reset_period` | 字符串 | `"session"` | 显示哪个重置时间：`"session"`（5小时窗口）或 `"weekly"`（7天窗口） |
+| `reset_format` | 字符串 | `"time"` | 重置时间的显示格式：`"time"`（例如 `2-22-13`）或 `"duration"`（例如 `4h 52m`） |
+
+配置示例：
+
+```toml
+[[segments]]
+id = "usage"
+enabled = true
+
+[segments.options]
+reset_period = "session"
+reset_format = "duration"
+cache_duration = 180
+```
 
 ## 系统要求
 


### PR DESCRIPTION
## Summary

- The usage segment was displaying the 5-hour (session) utilization percentage paired with the 7-day (weekly) reset time — a confusing mismatch. Now the reset time shown corresponds to the period being displayed.
- Adds a `reset_period` option to explicitly control which reset time is shown (`"session"` or `"weekly"`, default: `"session"`).
- Adds a `reset_format` option to display the reset as a countdown duration instead of a clock time (e.g. `4h 52m` instead of `2-22-13`).
- Documents all Usage segment options in README.md and README.zh.md.

## New options

| Option | Type | Default | Description |
|---|---|---|---|
| `reset_period` | string | `"session"` | `"session"` (5-hour window) or `"weekly"` (7-day window) |
| `reset_format` | string | `"time"` | `"time"` (e.g. `2-22-13`) or `"duration"` (e.g. `4h 52m`) |

Example:
```toml
[[segments]]
id = "usage"
enabled = true

[segments.options]
reset_period = "session"
reset_format = "duration"
```

## Test plan

- [ ] Verify usage segment shows session reset time by default (not weekly)
- [ ] Verify `reset_period = "weekly"` shows the 7-day reset time
- [ ] Verify `reset_format = "duration"` shows countdown (e.g. `4h 52m`)
- [ ] Verify `reset_format = "time"` shows existing clock format
- [ ] Verify old cache files (with `resets_at` field) trigger a fresh API fetch gracefully
- [ ] Verify both READMEs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align usage segment reset time with the displayed period and introduce configurable reset display options.

New Features:
- Add configurable reset_period option to choose between session (5-hour) and weekly (7-day) reset times in the usage segment.
- Add reset_format option to display reset time either as an absolute time or as a countdown duration.

Bug Fixes:
- Ensure the usage segment shows a reset time that matches the utilization period being displayed instead of always using the weekly reset.

Enhancements:
- Extend cached API usage data to store separate reset timestamps for session and weekly periods and handle legacy cache entries gracefully.

Documentation:
- Document all usage segment configuration options, including reset_period and reset_format, in both English and Chinese READMEs.