### PR TITLE
feat: support nix flake and minimize rust binary size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ CLAUDE.md
 PRD.md
 .claude/
 tests/
+
+# Ignore build outputs from performing a nix-build or `nix build` command
+result
+result-*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,10 @@ dirs = "6.0"
 regex = "1.0"
 tree-sitter = "0.26"
 tree-sitter-javascript = "0.25"
+
+[profile.release]
+opt-level = "z"
+strip = true
+lto = true
+codegen-units = 1
+panic = "abort"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782012058,
+        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,107 @@
+{
+  description = "A flake for CCometixLine";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts"; # https://flake.parts/
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      flake-parts,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      perSystem =
+        {
+          self',
+          system,
+          pkgs,
+          lib,
+          ...
+        }:
+        let
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+          buildInputs = with pkgs; [ ];
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              # includes already:
+              # rustc
+              # cargo
+              # rust-std
+              # rust-docs
+              # rustfmt-preview
+              # clippy-preview
+              "rust-src"
+              "rust-analyzer"
+            ];
+          };
+          rustPlatform = pkgs.makeRustPlatform {
+            cargo = pkgs.rust-bin.stable.latest.minimal;
+            rustc = pkgs.rust-bin.stable.latest.minimal;
+          };
+          cargoToml = fromTOML (builtins.readFile ./Cargo.toml);
+        in
+        {
+          # overlay
+          # https://flake.parts/overlays.html#consuming-an-overlay
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ (import inputs.rust-overlay) ];
+          };
+          # build package
+          packages.default = rustPlatform.buildRustPackage (finalAttrs: {
+            inherit nativeBuildInputs;
+            inherit buildInputs;
+
+            pname = cargoToml.package.name;
+            version = cargoToml.package.version;
+            src = ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              allowBuiltinFetchGit = true;
+            };
+
+            # Disable cargo-auditable until https://github.com/rust-secure-code/cargo-auditable/issues/124 is fixed
+            auditable = false;
+
+            meta = {
+              homepage = "https://github.com/Haleclipse/CCometixLine";
+              description = "Claude Code statusline tool written in Rust";
+              license = with lib.licenses; [
+                mit
+              ];
+              mainProgram = cargoToml.package.name;
+            };
+          });
+          # dev shell
+          devShells.default = pkgs.mkShell {
+            name = "develop-shell";
+            # use packages dependency
+            inputsFrom = [ self'.packages.default ];
+            packages = [ rustToolchain ];
+            env = {
+              RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+            };
+            shellHook = ''
+              echo "Rust development shell ready! 🦀 $(rustc --version)"
+            '';
+          };
+        };
+    };
+}


### PR DESCRIPTION
I use it on Nix, but the upstream repository doesn't support it yet. I've added Nix flake support in this PR and using it in my home-manager configuration.

Additionally, minimize rust binary size.

## Summary by Sourcery

Add Nix flake support and tune the Rust release build profile for smaller binaries.

New Features:
- Provide a Nix flake definition to build and package the project across common Linux and macOS systems.
- Add a Nix development shell configuration with an appropriate Rust toolchain and environment setup.

Enhancements:
- Configure the Rust release profile to optimize for minimal binary size via more aggressive compilation settings.